### PR TITLE
fix unable to decode codes longer than 16 bytes error

### DIFF
--- a/sleighcraft/src/cpp/bridge/disasm.cpp
+++ b/sleighcraft/src/cpp/bridge/disasm.cpp
@@ -75,7 +75,7 @@ void SleighProxy::decode_with(RustAssemblyEmit& asm_emit, RustPcodeEmit& pcode_e
 void RustLoadImageProxy::loadFill(uint1 *ptr, int4 size, const Address &address) {
     Address addr = const_cast <Address& > (address);
     uint8_t* array = (uint8_t*)ptr;
-    rust::Slice<::std::uint8_t> slice{array,16};
+    rust::Slice<::std::uint8_t> slice{array,(unsigned long)bufSize()};
     const auto addr_proxy = AddressProxy{addr};
     load_image.load_fill(slice, addr_proxy);
 }

--- a/sleighcraft/src/sleigh.rs
+++ b/sleighcraft/src/sleigh.rs
@@ -673,7 +673,7 @@ impl LoadImage for PlainLoadImage {
         let size = self.buf.len();
         let max = self.start + (size as u64 - 1);
 
-        for i in 0..size {
+        for i in 0..16 {
             let cur_off = start_off + i as u64;
             if self.start <= cur_off && max >= cur_off {
                 let offset = (cur_off - self.start) as usize;


### PR DESCRIPTION
Fix the problem that more than 16 bytes cannot be decode due to incorrect load_fill length setting