### PR TITLE
fix unable to decode codes longer than 16 bytes error

### DIFF
--- a/sleighcraft/src/cpp/bridge/disasm.cpp
+++ b/sleighcraft/src/cpp/bridge/disasm.cpp
@@ -75,7 +75,7 @@ void SleighProxy::decode_with(RustAssemblyEmit& asm_emit, RustPcodeEmit& pcode_e
 void RustLoadImageProxy::loadFill(uint1 *ptr, int4 size, const Address &address) {
     Address addr = const_cast <Address& > (address);
     uint8_t* array = (uint8_t*)ptr;
-    rust::Slice<::std::uint8_t> slice{array,16};
+    rust::Slice<::std::uint8_t> slice{array,(unsigned long)bufSize()};
     const auto addr_proxy = AddressProxy{addr};
     load_image.load_fill(slice, addr_proxy);
 }

--- a/sleighcraft/src/cpp/bridge/disasm.cpp
+++ b/sleighcraft/src/cpp/bridge/disasm.cpp
@@ -75,7 +75,7 @@ void SleighProxy::decode_with(RustAssemblyEmit& asm_emit, RustPcodeEmit& pcode_e
 void RustLoadImageProxy::loadFill(uint1 *ptr, int4 size, const Address &address) {
     Address addr = const_cast <Address& > (address);
     uint8_t* array = (uint8_t*)ptr;
-    rust::Slice<::std::uint8_t> slice{array,(unsigned long)bufSize()};
+    rust::Slice<::std::uint8_t> slice{array,(unsigned long)size};
     const auto addr_proxy = AddressProxy{addr};
     load_image.load_fill(slice, addr_proxy);
 }

--- a/sleighcraft/src/sleigh.rs
+++ b/sleighcraft/src/sleigh.rs
@@ -670,11 +670,8 @@ pub struct PlainLoadImage {
 impl LoadImage for PlainLoadImage {
     fn load_fill(&mut self, ptr: &mut [u8], addr: &AddressProxy) {
         let start_off = addr.get_offset() as u64;
-        let mut size = 16;
-        if self.buf.len() <= 16 {
-            size = self.buf.len()
-        }
-        let max = self.start + (size as u64 - 1);
+        let size = ptr.len();
+        let max = self.start + (self.buf.len() as u64 - 1);
 
         for i in 0..size {
             let cur_off = start_off + i as u64;

--- a/sleighcraft/src/sleigh.rs
+++ b/sleighcraft/src/sleigh.rs
@@ -670,7 +670,10 @@ pub struct PlainLoadImage {
 impl LoadImage for PlainLoadImage {
     fn load_fill(&mut self, ptr: &mut [u8], addr: &AddressProxy) {
         let start_off = addr.get_offset() as u64;
-        let size = self.buf.len();
+        let mut size = 16;
+        if self.buf.len() <= 16 {
+            size = self.buf.len()
+        }
         let max = self.start + (size as u64 - 1);
 
         for i in 0..size {


### PR DESCRIPTION
1.Fix the problem that more than 16 bytes cannot be decode due to incorrect load_fill length setting
2.Adjust load_fill loop parameters